### PR TITLE
Use correct exception in rcon example

### DIFF
--- a/code/rcon.html
+++ b/code/rcon.html
@@ -28,7 +28,7 @@ languages:
     begin
       server.rcon_auth('passw0rd')
       puts server.rcon_exec('status')
-    rescue RCONNoAuthException
+    rescue RCONNoAuthError
       warn 'Could not authenticate with the game server.'
     end
 ---


### PR DESCRIPTION
````ruby
$ irb
irb(main):001:0> require 'steam-condenser'
=> true
irb(main):002:0> RCONNoAuthException
NameError: uninitialized constant RCONNoAuthException
        from (irb):3
        from /usr/bin/irb:11:in `<main>'
irb(main):003:0> RCONNoAuthError
=> RCONNoAuthError
````